### PR TITLE
Fix: Use absolute URL for open graph images

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,12 +11,12 @@
 
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Shelf">
-  <meta property="og:image" content="/og-image.png">
+  <meta property="og:image" content="https://shelf.iambhvsh.in/og-image.png">
   <meta property="og:image:alt" content="Shelf App Logo">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@iambhvsh">
-  <meta name="twitter:image" content="/og-image.png">
+  <meta name="twitter:image" content="https://shelf.iambhvsh.in/og-image.png">
   <meta name="twitter:image:alt" content="Shelf App Logo">
 
   <script>


### PR DESCRIPTION
Fixes the Open Graph and Twitter image preview metadata to use absolute URLs.

---
*PR created automatically by Jules for task [5065118468648752581](https://jules.google.com/task/5065118468648752581) started by @iambhvsh*